### PR TITLE
avoids duplicate confirmation

### DIFF
--- a/freeze_version.py
+++ b/freeze_version.py
@@ -11,7 +11,7 @@ sha = repo.head.object.hexsha
 
 build_date = date.today().strftime('%Y-%m-%d')
 
-version = '0.0.15'
+version = '0.0.16'
 
 with open(version_file_path, 'w+') as version_file:
     version_file.write("version = '{}'\n".format(version))

--- a/src/python_ms_core/core/topic/topic.py
+++ b/src/python_ms_core/core/topic/topic.py
@@ -49,7 +49,6 @@ class Callback:
                     for message in topic_receiver:
                         try:
                             self.process_message(message=str(message)) # sync call. [By default 1minute ] -> lock renewal for 300 seconds
-                            topic_receiver.complete_message(message)
                         except Exception as e:
                             print(f'Error : {e}, Invalid message received : {message}')
                         finally:


### PR DESCRIPTION
Duplicate confirmation of message is avoided
- The code confirms/completes the message twice which leads to an unhandled exception of MessageAlreadyCompleted. This code fixes that issue